### PR TITLE
Change distribution name to wbia-brambox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ def parse_requirements(fname='requirements.txt'):
     return packages
 
 
-NAME = 'wbia-tpl-brambox'
+NAME = 'wbia-brambox'
 
 
 MB_PYTHON_TAG = native_mb_python_tag()  # NOQA


### PR DESCRIPTION
The distribution name was `wbia-tpl-brambox`, which doesn't follow the
other tpl libraries like `wbia-pydarknet`.

When trying to install `wbia-tpl-lightnet`:

```
+ cd /wbia/lightnet
+ /virtualenv/env3/bin/pip install -r requirements.txt
Requirement already satisfied: setuptools>=34.1.0 in /virtualenv/env3/lib/python3.6/site-packages (from -r requirements/build.txt (line 1)) (47.3.1)
Requirement already satisfied: wheel in /virtualenv/env3/lib/python3.6/site-packages (from -r requirements/build.txt (line 2)) (0.34.2)
Requirement already satisfied: numpy in /virtualenv/env3/lib/python3.6/site-packages (from -r requirements/runtime.txt (line 1)) (1.17.0)
Requirement already satisfied: torchvision in /virtualenv/env3/lib/python3.6/site-packages (from -r requirements/runtime.txt (line 2)) (0.2.1)
ERROR: Could not find a version that satisfies the requirement wbia-brambox (from -r requirements/runtime.txt (line 3)) (from versions: none)
ERROR: No matching distribution found for wbia-brambox (from -r requirements/runtime.txt (line 3))
```

It's expecting `wbia-brambox`, consistent with how the other tpl libraries are
named.