### PR TITLE
Change runtime requirement from pillow-simd to Pillow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build wheel
         env:
-          CIBW_SKIP: cp27-* pp27-* pp36-*
+          CIBW_SKIP: cp27-* pp27-* cp35-* pp35-* pp36-*
           CIBW_BEFORE_BUILD_LINUX: bash scripts/ci_prepare_centos_for_build.sh
           CIBW_BEFORE_BUILD_MACOS: bash scripts/ci_prepare_macos_for_build.sh
           CIBW_TEST_COMMAND: python -c "import brambox; from brambox.__main__ import main; main()"

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,5 @@
 matplotlib
 numpy
-pillow-simd
+Pillow
 pyyaml
 scipy

--- a/scripts/ci_prepare_macos_for_build.sh
+++ b/scripts/ci_prepare_macos_for_build.sh
@@ -14,7 +14,7 @@ sudo port selfupdate
 # Install ports if MacPorts install location is not present
 sudo port install \
     tiff \
-    libjpeg-turbo \
     zlib \
     webp \
     lcms2
+    # libjpeg-turbo # tiff depends on jpeg and causes conflict with libjpeg-turbo

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from os.path import exists
 from collections import OrderedDict
 
-# from setuptools import find_packages
+from setuptools import find_packages
 from skbuild import setup
 
 
@@ -211,9 +211,7 @@ KWARGS = OrderedDict(
         'tag_regex': '^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$',
         'local_scheme': 'dirty-tag',
     },
-    # packages=find_packages(),
-    packages=['brambox'],
-    package_dir={'brambox': 'brambox'},
+    packages=find_packages(),
     include_package_data=False,
     # List of classifiers available at:
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
"pillow-simd" is an alternative of Pillow.  We install Pillow in
wildbook-ia so we can't install "pillow-simd" in wbia-tpl-brambox, as it
overwrites the PIL directory.